### PR TITLE
added links to email-id and phone-no via anchor tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,11 +214,11 @@
                        Chaibasa Jharkhand PIN 833215, India
                     </p>
                     <p class="email-id"><i class="far fa-envelope"></i>
-                        cordinatortigjh@gmail.com
+                        <a href="mailto:cordinatortigjh@gmail.com">cordinatortigjh@gmail.com</a>
                     </p>
                     <h4>
                         <i class="fa-solid fa-phone" style="color: #fff;"></i>
-                         +91 - 9062941530
+                        <a href="tel:+91-9062941530">+91 - 9062941530</a>     
                     </h4>
                 </div>
                 <div class="col col3" id="link">

--- a/style.css
+++ b/style.css
@@ -243,12 +243,12 @@ footer {
   color: white;
   transition-duration: 0.7s;
 }
-.col2 h4{
+.col2 a{
   font-size: 16px;
   font-weight: 100;
   color: #ff523b;
 }
-.col2 h4:hover{
+.col2 a:hover{
   font-size: 16px;
   font-weight: 100;
   color: white;


### PR DESCRIPTION
The email id and phone number in contact was not linked via anchor tag. So I have linked it to your mail and phone number by retaining all its css properties . Now just by clicking on the mail it will open mail to send an email to you and on clicking to number it will call to your number.

I have worked on the issue #280 .

<img width="589" alt="Screenshot 2023-05-23 at 7 59 31 PM" src="https://github.com/NageshMandal/Engineering-Notes-Website/assets/112635806/b9832652-e0e5-4be2-9d21-37774f3e83be">

Kindly review it once and inform me if some changes are needed @NageshMandal  .
Thank you